### PR TITLE
Use unattended flag when installing ohmyzsh

### DIFF
--- a/setup/init.sh
+++ b/setup/init.sh
@@ -14,7 +14,7 @@ git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 
 # Oh My Zsh
 echo "Installing Oh My Zsh"
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 
 # asdf
 if [ ! -d "$HOME/.asdf" ]; then


### PR DESCRIPTION
Closes https://github.com/kevinmcgill/dotfiles/issues/3

OhMyZsh can be installed with an `--unattended` flag.

https://github.com/ohmyzsh/ohmyzsh?tab=readme-ov-file#unattended-install